### PR TITLE
Fix pdf worker url resolution

### DIFF
--- a/src/components/Common/PDFViewer.tsx
+++ b/src/components/Common/PDFViewer.tsx
@@ -2,10 +2,7 @@ import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/esm/Page/AnnotationLayer.css";
 import "react-pdf/dist/esm/Page/TextLayer.css";
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  "pdfjs-dist/build/pdf.worker.min.mjs",
-  import.meta.url,
-).toString();
+pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
 export default function PDFViewer(
   props: Readonly<{


### PR DESCRIPTION
## Proposed Changes

- Fixes PDF worker load failure.
- Updates `pdfjs.GlobalWorkerOptions.workerSrc` to use a CDN URL (`unpkg.com`) that dynamically matches the installed `pdfjs-dist` version.
- **Why:** The previous `new URL()` constructor incorrectly resolved the `pdfjs-dist` worker path relative to the current module, leading to an invalid URL and worker load failure. Using a CDN ensures correct and version-compatible worker loading.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices

---
<a href="https://cursor.com/background-agent?bcId=bc-a519def1-ff46-4416-b875-bdfd4356dc34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a519def1-ff46-4416-b875-bdfd4356dc34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>