### PR TITLE
Fix pdf worker url resolution

### DIFF
--- a/src/components/Common/PDFViewer.tsx
+++ b/src/components/Common/PDFViewer.tsx
@@ -2,10 +2,7 @@ import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/esm/Page/AnnotationLayer.css";
 import "react-pdf/dist/esm/Page/TextLayer.css";
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  "pdfjs-dist/build/pdf.worker.min.mjs",
-  import.meta.url,
-).toString();
+pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
 
 export default function PDFViewer(
   props: Readonly<{

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -11,6 +11,7 @@ import path from "path";
 import { defineConfig, loadEnv } from "vite";
 import checker from "vite-plugin-checker";
 import { VitePWA } from "vite-plugin-pwa";
+import { viteStaticCopy } from "vite-plugin-static-copy";
 import { z } from "zod";
 
 import { careConsoleArt } from "./plugins/careConsoleArt";
@@ -195,11 +196,14 @@ export default defineConfig(({ mode }) => {
             .describe("Optional: Space-separated list of CDN URLs"),
         },
       }),
-      // viteStaticCopy({
-      //   targets: [{
-
-      //   }],
-      // }),
+      viteStaticCopy({
+        targets: [
+          {
+            src: "node_modules/pdfjs-dist/build/pdf.worker.min.mjs",
+            dest: "",
+          },
+        ],
+      }),
       react(),
       reactScan({
         enable:


### PR DESCRIPTION
## Proposed Changes

- Fixes #issue_number
- Configured `vite-plugin-static-copy` to copy `pdf.worker.min.mjs` from `node_modules` to the public directory.
- Updated `src/components/Common/PDFViewer.tsx` to reference the PDF worker using a static path (`/pdf.worker.min.mjs`).

The previous `new URL(..., import.meta.url)` approach incorrectly resolved the package path for `pdfjs-dist/build/pdf.worker.min.mjs`, causing the PDF worker to fail loading. This change ensures the worker file is correctly available and referenced, resolving the PDF functionality issue without relying on CDNs.

@ohcnetwork/care-fe-code-reviewers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Update [product documentation](https://docs.ohc.network).
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Request for Peer Reviews
- [ ] Completion of QA in Mobile Devices
- [ ] Completion of QA in Desktop Devices

---
<a href="https://cursor.com/background-agent?bcId=bc-2f210d61-17ba-4168-aec2-c9d646c949b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f210d61-17ba-4168-aec2-c9d646c949b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>